### PR TITLE
Adjust simulation iteration count via ctr modification

### DIFF
--- a/riscv_crt0/CMakeLists.txt
+++ b/riscv_crt0/CMakeLists.txt
@@ -2,4 +2,12 @@ cmake_minimum_required(VERSION 3.10)
 
 project(riscv_crt0 C CXX ASM)
 
+if(NOT DEFINED SIMULATION_RUNS_COUNT)
+    set(SIMULATION_RUNS_COUNT 1)
+endif()
+
+message(STATUS "SIMULATION_RUNS_COUNT is set to: ${SIMULATION_RUNS_COUNT}")
+
 add_library(etiss_crt0 STATIC crt0.S fixes.c trap_handler.c)
+
+target_compile_definitions(etiss_crt0 PRIVATE SIMULATION_RUNS=${SIMULATION_RUNS_COUNT})

--- a/riscv_crt0/crt0.S
+++ b/riscv_crt0/crt0.S
@@ -28,6 +28,9 @@
 #error __SIZEOF_POINTER__ neither 4 nor 8
 #endif
 
+#ifndef SIMULATION_RUNS
+#define SIMULATION_RUNS 1
+#endif
 .text
 
 .global _start
@@ -64,6 +67,13 @@ _start:
   # Run global initialization functions
   call    __libc_init_array
 
+  # load simulation runs count.
+  li s11, SIMULATION_RUNS
+
+simulation_loop:
+
+  beqz s11, end_simulation_loop
+
   # call user code
   # main(int argc, char *argv[]);
   # main(0, 0);
@@ -73,6 +83,11 @@ _start:
   li      a2, 0 # set envp = NULL just in case
   call    main
 
+  addi s11, s11, -1
+
+  bnez s11, simulation_loop
+
+end_simulation_loop:
   tail    exit
 
 .p2align 2 # align on 4-byte boundary


### PR DESCRIPTION
Modified the CMakeLists.txt to support calling the main function of the example code multiple times based on a compile-time variable SIMULATION_RUNS_COUNT. If not explicitly set, the default is 1. This enables simulation scenarios to control how many times the simulated code shall execute.